### PR TITLE
Fix #9; adds static "type" property to conform to i18next API

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,15 +36,15 @@
         "@types/lodash.set": "^4.3.6",
         "@types/webpack-env": "^1.15.1",
         "eslint": "^6.8.0",
+        "i18next": "^19.3.3",
+        "prettier": "^1.19.1",
         "ts-node": "^8.7.0",
-        "typescript": "^3.8.3",
-        "prettier": "^1.19.1"
+        "typescript": "^3.8.3"
     },
     "peerDependencies": {
         "@types/webpack-env": "^1.15.1"
     },
     "dependencies": {
-        "i18next": "^19.3.3",
         "lodash.set": "^4.3.2",
         "tslib": "^1.11.1"
     }

--- a/src/backend-plugin.ts
+++ b/src/backend-plugin.ts
@@ -65,7 +65,7 @@ export class WebpackBackend implements Module {
                             return;
                         }
                         if (this.keys.includes(builtKey) === false) {
-                            console.error(new Error(`Namespace "${namespace}" for language "${lang}" was not found!`));
+                            callback(new Error(`Namespace "${namespace}" for language "${lang}" was not found!`), null);
                             return;
                         }
                         const json = await this.jsons(builtKey);

--- a/src/backend-plugin.ts
+++ b/src/backend-plugin.ts
@@ -1,4 +1,4 @@
-import { ReadCallback, Services, Module, MultiReadCallback } from "i18next";
+import type { ReadCallback, Services, Module, MultiReadCallback } from "i18next";
 import set from "lodash.set";
 
 export interface WebpackBackendOptions {

--- a/src/backend-plugin.ts
+++ b/src/backend-plugin.ts
@@ -51,8 +51,8 @@ export class WebpackBackend implements Module {
         const translations = {};
 
         await Promise.all(
-            namespaces.map(async namespace => {
-                return Promise.all(
+            namespaces.map(namespace =>
+                Promise.all(
                     languages.map(async lang => {
                         const builtKey = `./${lang}/${namespace}.json`;
                         if (this.jsons == null) {
@@ -78,8 +78,8 @@ export class WebpackBackend implements Module {
                         const json = await this.jsons(builtKey);
                         set(translations, `${lang}.${namespace}`, json);
                     })
-                );
-            })
+                )
+            )
         );
 
         if (Object.keys(translations).length === 0) {

--- a/src/backend-plugin.ts
+++ b/src/backend-plugin.ts
@@ -6,6 +6,7 @@ export interface WebpackBackendOptions {
 }
 
 export class WebpackBackend implements Module {
+    public static readonly type = "backend";
     public readonly type = "backend";
     private jsons: __WebpackModuleApi.RequireContext | null = null;
     private keys: string[] = [];
@@ -65,7 +66,13 @@ export class WebpackBackend implements Module {
                             return;
                         }
                         if (this.keys.includes(builtKey) === false) {
-                            callback(new Error(`Namespace "${namespace}" for language "${lang}" was not found!`), null);
+                            callback(
+                                new Error(`Namespace "${namespace}" for language "${lang}" was not found!`),
+                                // TODO: Fix this when types are up to date with newest implementation.
+                                // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+                                // @ts-ignore
+                                null
+                            );
                             return;
                         }
                         const json = await this.jsons(builtKey);


### PR DESCRIPTION
## What changed?

- See title; a _static_ `type` property is required, [per i18next documentation](https://www.i18next.com/misc/creating-own-plugins#make-sure-to-set-the-plugin-type)
- Raises plugin error when namespace is missing, rather than a `console.error()` (which I suspect was accidental)
- Turns `i18next` into a dev-only dependency since only its types are used; it isn't needed at plugin runtime

## Test plan

- [x] Ensure `npm run build` completes successfully